### PR TITLE
Unique, periodically refreshed hash

### DIFF
--- a/wwwroot/index.php
+++ b/wwwroot/index.php
@@ -59,4 +59,28 @@ $isHorz = isset($_GET['horz']) || @$_GET['t'] == 'horz';
   </div>
 </body>
 
+<script>
+  document.addEventListener('DOMContentLoaded', (event) => {
+    if(typeof crypto.randomUUID === 'undefined') {
+      return;
+    }
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const mode = (urlParams.get('horz') !== null) ? 'horz' : 'vert';
+    const link = document.querySelector(".me");
+
+    function refreshHash() {
+      let key = crypto.randomUUID();
+      link.setAttribute('href', `?${mode}` + "#" + key);
+      window.location.hash = key;
+    }
+
+    refreshHash();
+
+    window.setInterval(() => {
+      refreshHash();
+    }, 1000);
+  });
+</script>
+
 </html>


### PR DESCRIPTION
Adds a unique hash that is refreshed every second, so certains browsers don't detect multiple separators with the same name as duplicates and remove them.

The typeof check is there because crypto.randomUUID() has only been standard/implemented  for a couple years (and I wanted to be extra cautious), and as a placeholder in case a polyfill is ever to be used; so it will work exactly the same as before in case someone is using a really outdated browser.

Should address #12 